### PR TITLE
Updater to GNOME 48

### DIFF
--- a/panel-workspace-scroll@polymeilex.github.io/metadata.json
+++ b/panel-workspace-scroll@polymeilex.github.io/metadata.json
@@ -6,7 +6,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "original-authors": "marynczakbartlomiej@gmail.com",
   "url": "https://github.com/PolyMeilex/gnome-shell-extension-panel-workspace-scroll"


### PR DESCRIPTION
Hello!

Thank you for creating and maintaining this extension. I've used it for a while and it's really helpful for quick mouse-only navigation. 

I've been using this for a few weeks on Gnome 48 already and I didn't notice any issues so it might be worth upgrading it to the new version. I've also didn't notice anything related in https://gjs.guide/extensions/upgrading/gnome-shell-48.html.