### PR TITLE
Update metadata.json to GS 49

### DIFF
--- a/panel-workspace-scroll@polymeilex.github.io/metadata.json
+++ b/panel-workspace-scroll@polymeilex.github.io/metadata.json
@@ -7,7 +7,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "original-authors": "marynczakbartlomiej@gmail.com",
   "url": "https://github.com/PolyMeilex/gnome-shell-extension-panel-workspace-scroll"


### PR DESCRIPTION
Adds shell version 49 to compatibility list.

No user side bugs found so far.