### PR TITLE
Add middle-click to toggle overview while scrolling workspaces

### DIFF
--- a/panel-workspace-scroll@polymeilex.github.io/extension.js
+++ b/panel-workspace-scroll@polymeilex.github.io/extension.js
@@ -3,12 +3,23 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 export default class PanelWorkspaceScrollExtension {
     enable() {
         this.scrollEventId = Main.panel.connect('scroll-event', (_actor, event) => Main.wm.handleWorkspaceScroll(event));
+        this.clickEventId = Main.panel.connect('button-press-event', (_actor, event) => {
+            if (event.get_button() === 2) {  // Middle mouse button (button index 2) .  The left button is 1, right is 3 .
+                Main.overview.toggle();
+                return Clutter.EVENT_STOP;
+            }
+            return Clutter.EVENT_PROPAGATE;
+        });
     }
 
     disable() {
         if (this.scrollEventId != null) {
             Main.panel.disconnect(this.scrollEventId);
             this.scrollEventId = null;
+        }
+        if (this.clickEventId) {
+            Main.panel.disconnect(this.clickEventId);
+            this.clickEventId = null;
         }
     }
 }

--- a/panel-workspace-scroll@polymeilex.github.io/metadata.json
+++ b/panel-workspace-scroll@polymeilex.github.io/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "panel-workspace-scroll@polymeilex.github.io",
   "extension-id": "panel-workspace-scroll",
   "name": "Panel Workspace Scroll",
-  "description": "Switch workspace by mouse scroll on the panel.\nIn contrast to alternative extensions purpose of this one is to use the native scroll handler of gnome-shell, so workspace scroll should behave exactly the same as overview scroll or workspace indicator scroll.",
+  "description": "Switch workspace by mouse scroll on the panel and see the Overview by middle-clicking anywhere on the panel.\nIn contrast to alternative extensions purpose of this one is to use the native scroll handler of gnome-shell, so workspace scroll should behave exactly the same as overview scroll or workspace indicator scroll.",
   "shell-version": [
     "45",
     "46",


### PR DESCRIPTION
This PR adds the ability to toggle the Activities Overview by middle-clicking anywhere on the panel.
